### PR TITLE
vanilla-like bronze repairing

### DIFF
--- a/scripts/bronzeRework.zs
+++ b/scripts/bronzeRework.zs
@@ -1,5 +1,6 @@
 import crafttweaker.item.IItemStack;
 import crafttweaker.item.IIngredient;
+import crafttweaker.item.IItemCondition;
 import mods.jei.JEI;
 
 #REMOVE copper and tin
@@ -174,41 +175,47 @@ mods.jei.JEI.addDescription(<spartanshields:shield_basic_bronze>, "Also know as 
 
 //VANILLA ANVIL REPAIR
 // Anvil.addRecipe(IIngredient left, IIngredient right, IItemStack output, int cost, @Optional IRecipeFunction function)
-#armor
-mods.rockytweaks.Anvil.addRecipe(<atop:mud_helmet>.anyDamage(), <contenttweaker:material_part>, <atop:mud_helmet>, 1,
-function(out, ins, cInfo){
-    return ins.left.withDamage(max(0,ins.left.damage - 100));
-});
-mods.rockytweaks.Anvil.addRecipe(<atop:mud_chestplate>.anyDamage(), <contenttweaker:material_part>, <atop:mud_chestplate>, 1,
-function(out, ins, cInfo){
-    return ins.left.withDamage(max(0,ins.left.damage - 137));
-});
-mods.rockytweaks.Anvil.addRecipe(<atop:mud_leggings>.anyDamage(), <contenttweaker:material_part>, <atop:mud_leggings>, 1,
-function(out, ins, cInfo){
-    return ins.left.withDamage(max(0,ins.left.damage - 130));
-});
-mods.rockytweaks.Anvil.addRecipe(<atop:mud_boots>.anyDamage(), <contenttweaker:material_part>, <atop:mud_boots>, 1,
-function(out, ins, cInfo){
-    return ins.left.withDamage(max(0,ins.left.damage - 115));
-});
-#tools
-mods.rockytweaks.Anvil.addRecipe(<atop:mud_sword>.anyDamage(), <contenttweaker:material_part>, <atop:mud_sword>, 1,
-function(out, ins, cInfo){
-    return ins.left.withDamage(max(0,ins.left.damage - 113));
-});
-mods.rockytweaks.Anvil.addRecipe(<atop:mud_shovel>.anyDamage(), <contenttweaker:material_part>, <atop:mud_shovel>, 1,
-function(out, ins, cInfo){
-    return ins.left.withDamage(max(0,ins.left.damage - 105));
-});
-mods.rockytweaks.Anvil.addRecipe(<atop:mud_pickaxe>.anyDamage(), <contenttweaker:material_part>, <atop:mud_pickaxe>, 1,
-function(out, ins, cInfo){
-    return ins.left.withDamage(max(0,ins.left.damage - 105));
-});
-mods.rockytweaks.Anvil.addRecipe(<atop:mud_axe>.anyDamage(), <contenttweaker:material_part>, <atop:mud_axe>, 1,
-function(out, ins, cInfo){
-    return ins.left.withDamage(max(0,ins.left.damage - 105));
-});
-mods.rockytweaks.Anvil.addRecipe(<atop:mud_hoe>.anyDamage(), <contenttweaker:material_part>, <atop:mud_hoe>, 1,
-function(out, ins, cInfo){
-    return ins.left.withDamage(max(0,ins.left.damage - 105));
-});
+
+// item conditions DO NOT work on these IIngredients, need to become ifs inside IRecipeFunction
+// except anyDamage(), which needs to be on first IIngredient
+
+var itemArray = [<atop:mud_helmet>, <atop:mud_chestplate>, <atop:mud_leggings>, <atop:mud_boots>, <atop:mud_sword>, <atop:mud_shovel>, <atop:mud_pickaxe>, <atop:mud_axe>, <atop:mud_hoe>] as IItemStack[];
+
+for item in itemArray
+{
+	mods.rockytweaks.Anvil.addRecipe(item.anyDamage(), <contenttweaker:material_part>, item, 1,
+	function(out, ins, cInfo){
+		if (ins.left.damage == 0) {
+			return null;
+		} else {
+			return ins.left.withDamage(max(0, ins.left.damage - ((0.25 * ins.left.maxDamage) as int)));
+		}
+	});
+	
+	mods.rockytweaks.Anvil.addRecipe(item.anyDamage(), <contenttweaker:material_part> * 2, item, 2,
+	function(out, ins, cInfo){
+		if (ins.left.damage <= (0.25 * ins.left.maxDamage) as int) {
+			return null;
+		} else {
+			return ins.left.withDamage(max(0, ins.left.damage - ((0.50 * ins.left.maxDamage) as int)));
+		}
+	});
+	
+	mods.rockytweaks.Anvil.addRecipe(item.anyDamage(), <contenttweaker:material_part> * 3, item, 3,
+	function(out, ins, cInfo){
+		if (ins.left.damage <= (0.50 * ins.left.maxDamage) as int) {
+			return null;
+		} else {
+			return ins.left.withDamage(max(0, ins.left.damage - ((0.75 * ins.left.maxDamage) as int)));
+		}
+	});
+	
+	mods.rockytweaks.Anvil.addRecipe(item.anyDamage(), <contenttweaker:material_part> * 4, item, 4,
+	function(out, ins, cInfo){
+		if (ins.left.damage <= (0.75 * ins.left.maxDamage) as int) {
+			return null;
+		} else {
+			return ins.left.withDamage(0);
+		}
+	});
+}


### PR DESCRIPTION
Only issue is that if you put more ingots that the item needs to fully repair, and it needs less that 4, you won't be able to repair unless you put EXACTLY the required number of ingots (or less for partial repair).

I tried various ways to fix this, but nothing worked. I think there's only so much you can do with CraftTweaker instead of making your own mod to fix things.

I think that my code will be better UX, but that's up to you to decide.

I also tried to write similar code for atop.zs (BoP gem armor), but it always consumed one gem per repair. I think the issue is that right input is OreDictionary entry. Any thoughts on this?