### PR TITLE
Prevent Blur in Chat

### DIFF
--- a/config/blur.cfg
+++ b/config/blur.cfg
@@ -13,6 +13,7 @@ general {
     # A list of classes to be excluded from the blur shader. [default: [net.minecraft.client.gui.GuiChat]]
     S:guiExclusions <
         net.minecraft.client.gui.GuiChat
+        net.optifine.gui.GuiChatOF
      >
 
     # The radius of the blur effect. This controls how "strong" the blur is. [range: 1 ~ 100, default: 12]


### PR DESCRIPTION
Optifine overrides chat with its own class "net.optifine.gui.GuiChatOF," so adding the class to the "guiExclusions" list will prevent the blur mod from bluring the screen when pulling up the chat bar.